### PR TITLE
Add support for debug module

### DIFF
--- a/spikedetekt2/core/main.py
+++ b/spikedetekt2/core/main.py
@@ -184,6 +184,9 @@ def run(raw_data=None, experiment=None, prm=None, probe=None,
     assert not np.isnan(threshold.strong).any()
     debug("Threshold: " + str(threshold))
 
+    # Debug module.
+    diagnostics_script_path = prm.get('diagnostics_script_path', None)
+
     # Progress bar.
     progress_bar = ProgressReporter(period=30.)
     nspikes = 0
@@ -248,6 +251,11 @@ def run(raw_data=None, experiment=None, prm=None, probe=None,
         waveforms = extract_waveforms(chunk_detect=chunk_detect,
             threshold=threshold, chunk_fil=chunk_fil, chunk_raw=chunk_raw,
             probe=probe, components=components, **prm)
+
+        # DEBUG module.
+        # Execute the debug script.
+        if diagnostics_script_path:
+            execfile(diagnostics_script_path)
 
         # Log number of spikes in the chunk.
         nspikes += len(waveforms)


### PR DESCRIPTION
This PR adds a new `diagnostics_script_path` option in the PRM file. Put the full path to a Python script and it will be executed after every chunk has been processed. Here are the available global and local variables when the script is executed:

``` python
# globals():
['connected_components', 'register', 'close_file_logger', 'read_raw',
 'get_threshold', 'apply_filter', 'project_pcs', 'FileLogger', 
 'create_file_logger', 'add_waveform', 'bandpass_filter', 'compute_pcs',
  'display_params', '__package__', 'convert_dtype', 'run', 'np', 
  'ProgressReporter', 'tb', '__doc__', 'BaseRawDataReader', 
  'ExperimentRawDataReader', 'excerpt_step', 'KwdRawDataReader', 
  '__warningregistry__', '__builtins__', '__file__', 'to_contiguous', 
  'DoubleThreshold', 'warn', 'apply_threshold', '__name__', 'iterkeys', 
  'info', 'exception', 'extract_waveform', 'logging', 'unregister', 'Probe', 
  'decimate', 'save_features', 'debug', 'extract_waveforms']

# locals():
['s_end', 'prm', 'chunk', 'probe', 'dead', 'waveforms', 'threshold', 
'diagnostics_script_path', 'nspikes', '_debug', 'progress_bar', 'experiment', 
'chunk_threshold', 'chunk_detect', 'rec', 'chunk_low_keep', 'chunk_low', 
'LOGGER_FILE', 'nchannels', 'chunk_fil', 'chunk_size', 'chunk_raw', 
'nsamples', 'nrecs', 'chunk_overlap', 'i', 'raw_data', 'j', 'filter', 
'components']
```

Need to merge https://github.com/klusta-team/kwiklib/pull/14 too.

This allows us (and users) to write custom diagnostics scripts without putting them in the spikedetekt repository.

cc @shabnamkadir 
