### PR TITLE
Changed PRM file format for KK_ prefix

### DIFF
--- a/spikedetekt2/core/script.py
+++ b/spikedetekt2/core/script.py
@@ -164,7 +164,6 @@ def run_klustakwik(filename, dir=None, **kwargs):
         # Set the KlustaKwik parameters.
         params = dict()
         for key, value in kwargs.iteritems():
-            print key
             if key[:3] == 'kk_':
                 params[key[3:]] = value
             


### PR DESCRIPTION
Changed the format of the PRM file. Now all KlustaKwik parameters must be prefixed by KK_ rather than being hard-coded in script.py.
