### PR TITLE
Fix masked PCA implementation

### DIFF
--- a/spikedetekt2/processing/pca.py
+++ b/spikedetekt2/processing/pca.py
@@ -33,7 +33,7 @@ def compute_pcs(x, npcs=None, masks=None):
 
     # Compute regularization cov matrix.
     if masks is not None:
-        unmasked = mask > 0
+        unmasked = masks > 0
         # The last dimension is now time. The second dimension is channel.
         x_swapped = np.swapaxes(x, 1, 2)
         # This is the list of all unmasked spikes on all channels.

--- a/spikedetekt2/processing/pca.py
+++ b/spikedetekt2/processing/pca.py
@@ -60,7 +60,7 @@ def compute_pcs(x, npcs=None, masks=None):
         # Don't compute the cov matrix if there are no unmasked spikes
         # on that channel.
         alpha = 1. / nspikes
-        if x_channel.shape[0] == 0:
+        if x_channel.shape[0] <= 1:
             cov = alpha * cov_reg
         else:
             cov_channel = np.cov(x_channel, rowvar=0)

--- a/spikedetekt2/processing/pca.py
+++ b/spikedetekt2/processing/pca.py
@@ -65,7 +65,7 @@ def compute_pcs(x, npcs=None, masks=None):
         else:
             cov_channel = np.cov(x_channel, rowvar=0)
             assert cov_channel.shape == (nsamples, nsamples)
-            cov = cov_reg + alpha * cov_channel
+            cov = alpha * cov_reg + cov_channel
         # Compute the eigenelements
         vals, vecs = np.linalg.eigh(cov)
         pcs = vecs.T.astype(np.float32)[np.argsort(vals)[::-1]]

--- a/spikedetekt2/processing/pca.py
+++ b/spikedetekt2/processing/pca.py
@@ -74,8 +74,15 @@ def compute_pcs(x, npcs=None, masks=None):
             pcs_list.append(pcs[:npcs,...])
         else:
             pcs_list.append(pcs)
-    # Return the concatenation of the PCs on all channels, along the 3d axis.
-    return np.dstack(pcs_list)
+    # Return the concatenation of the PCs on all channels, along the 3d axis,
+    # except if there is only one element in the 3d axis. In this case
+    # we convert to a 2D array.
+    pcs = np.dstack(pcs_list)
+    assert pcs.ndim == 3
+    if pcs.shape[2] == 1:
+        pcs = pcs[:, :, 0]
+        assert pcs.ndim == 2
+    return pcs
 
 def project_pcs(x, pcs):
     """Project data points onto principal components.


### PR DESCRIPTION
This PR implements the fix described by this e-mail from @kdharris101:

> The problem arises when there are no unmasked spikes on a given channel. In this case, setting the PCs to zero is a makes all features 0 on that channel. Even though all the points are masked, KK still has a problem because it replaces masked features with the noise mean and variance, which are zero.

> We should change the way we compute PCs to include regularization. This is the best solution, because it also solves another problem. If there were only 1 or 2 spikes unmasked on a given channel, the PCs would also be bogus. The way we could do this is to compute PCs as the eigenvectors of sigma + lamba * sigma0, where sigma is the covariance matrix of unmasked spikes only, and sigma0 is a regularization matrix.

> The best choice would be to make sigma0 be the covariance matrix of all unmasked spikes, whatever channel they were recorded from; that way, it would be a “prior” that if there are very few unmasked spikes from this channel, you assume it will be like all other channels. In this case, lambda could be something like 1/N_spikes, so that it is equivalent to one “virtual spike”.
