### PR TITLE
Added --convert-only option and another test

### DIFF
--- a/spikedetekt2/core/main.py
+++ b/spikedetekt2/core/main.py
@@ -172,7 +172,8 @@ def run(raw_data=None, experiment=None, prm=None, probe=None,
 
     # Log.
     if convert_only:
-        info("Starting file conversion only (only one chunk's spike detection) of SpikeDetekt version {1:s} on {0:s}".format((str(raw_data)), spikedetekt2.__version__))
+        info("Starting file conversion only. Klusta version {1:s}, on {0:s}".format((str(raw_data)), spikedetekt2.__version__))
+        info("Running spike detection on a single chunk of spikes only, so as to have some information")
         first_chunk_detected = False # horrible hack - detects spikes on one chunk only so KV doesn't complain
     else:
         info("Starting SpikeDetekt version {1:s} on {0:s}".format((str(raw_data)), spikedetekt2.__version__))
@@ -182,7 +183,6 @@ def run(raw_data=None, experiment=None, prm=None, probe=None,
     filter = bandpass_filter(**prm)
     
     if not (convert_only and first_chunk_detected):
-        info("Running spike detection on a single chunk of spikes only, so as to have some information")
         # Compute the strong threshold across excerpts uniformly scattered across the
         # whole recording.
         threshold = get_threshold(raw_data, filter=filter, 

--- a/spikedetekt2/core/main.py
+++ b/spikedetekt2/core/main.py
@@ -147,8 +147,8 @@ def close_file_logger(LOGGER_FILE):
 # -----------------------------------------------------------------------------
 # Main loop
 # -----------------------------------------------------------------------------
-def run(raw_data=None, experiment=None, prm=None, probe=None,
-        _debug=False):
+def run(raw_data=None, experiment=None, prm=None, probe=None, 
+        _debug=False, convert_only=False):
     """This main function takes raw data (either as a RawReader, or a path
     to a filename, or an array) and executes the main algorithm (filtering,
     spike detection, extraction...)."""
@@ -171,23 +171,29 @@ def run(raw_data=None, experiment=None, prm=None, probe=None,
         raw_data = read_raw(experiment)
 
     # Log.
-    info("Starting SpikeDetekt version {1:s} on {0:s}".format((str(raw_data)), spikedetekt2.__version__))
+    if convert_only:
+        info("Starting file conversion only (only one chunk's spike detection) of SpikeDetekt version {1:s} on {0:s}".format((str(raw_data)), spikedetekt2.__version__))
+        first_chunk_detected = False # horrible hack - detects spikes on one chunk only so KV doesn't complain
+    else:
+        info("Starting SpikeDetekt version {1:s} on {0:s}".format((str(raw_data)), spikedetekt2.__version__))
     debug("Parameters: \n" + (display_params(prm)))
 
     # Get the bandpass filter.
     filter = bandpass_filter(**prm)
+    
+    if not (convert_only and first_chunk_detected):
+        info("Running spike detection on a single chunk of spikes only, so as to have some information")
+        # Compute the strong threshold across excerpts uniformly scattered across the
+        # whole recording.
+        threshold = get_threshold(raw_data, filter=filter, 
+                                  channels=probe.channels, **prm)
+        assert not np.isnan(threshold.weak).any()
+        assert not np.isnan(threshold.strong).any()
+        debug("Threshold: " + str(threshold))
 
-    # Compute the strong threshold across excerpts uniformly scattered across the
-    # whole recording.
-    threshold = get_threshold(raw_data, filter=filter,
-                              channels=probe.channels, **prm)
-    assert not np.isnan(threshold.weak).any()
-    assert not np.isnan(threshold.strong).any()
-    debug("Threshold: " + str(threshold))
-
-    # Debug module.
-    diagnostics_script_path = prm.get('diagnostics_script_path', None)
-
+        # Debug module.
+        diagnostics_script_path = prm.get('diagnostics_script_path', None)
+    
     # Progress bar.
     progress_bar = ProgressReporter(period=30.)
     nspikes = 0
@@ -229,41 +235,44 @@ def run(raw_data=None, experiment=None, prm=None, probe=None,
             chunk_low = decimate(chunk_raw)
             chunk_low_keep = chunk_low[i//16:j//16,:]
             experiment.recordings[chunk.recording].low.append(convert_dtype(chunk_low_keep, np.int16))
+        
+        if not (convert_only and first_chunk_detected):
+            # Apply thresholds.
+            chunk_detect, chunk_threshold = apply_threshold(chunk_fil, 
+                threshold=threshold, **prm)
+        
+            # Remove dead channels.
+            dead = np.setdiff1d(np.arange(nchannels), probe.channels)
+            chunk_detect[:,dead] = 0
+            chunk_threshold.strong[:,dead] = 0
+            chunk_threshold.weak[:,dead] = 0
+        
+            # Find connected component (strong threshold). Return list of
+            # Component instances.
+            components = connected_components(
+                chunk_strong=chunk_threshold.strong, 
+                chunk_weak=chunk_threshold.weak, 
+                probe_adjacency_list=probe.adjacency_list,
+                chunk=chunk, **prm)
+        
+            # Now we extract the spike in each component.
+            waveforms = extract_waveforms(chunk_detect=chunk_detect,
+                threshold=threshold, chunk_fil=chunk_fil, chunk_raw=chunk_raw, 
+                probe=probe, components=components, **prm)
 
-        # Apply thresholds.
-        chunk_detect, chunk_threshold = apply_threshold(chunk_fil,
-            threshold=threshold, **prm)
-
-        # Remove dead channels.
-        dead = np.setdiff1d(np.arange(nchannels), probe.channels)
-        chunk_detect[:,dead] = 0
-        chunk_threshold.strong[:,dead] = 0
-        chunk_threshold.weak[:,dead] = 0
-
-        # Find connected component (strong threshold). Return list of
-        # Component instances.
-        components = connected_components(
-            chunk_strong=chunk_threshold.strong,
-            chunk_weak=chunk_threshold.weak,
-            probe_adjacency_list=probe.adjacency_list,
-            chunk=chunk, **prm)
-
-        # Now we extract the spike in each component.
-        waveforms = extract_waveforms(chunk_detect=chunk_detect,
-            threshold=threshold, chunk_fil=chunk_fil, chunk_raw=chunk_raw,
-            probe=probe, components=components, **prm)
-
-        # DEBUG module.
-        # Execute the debug script.
-        if diagnostics_script_path:
-            execfile(diagnostics_script_path)
-
-        # Log number of spikes in the chunk.
-        nspikes += len(waveforms)
-
-        # We sort waveforms by increasing order of fractional time.
-        [add_waveform(experiment, waveform) for waveform in sorted(waveforms)]
-
+            # DEBUG module.
+            # Execute the debug script.
+            if diagnostics_script_path:
+                execfile(diagnostics_script_path)
+        
+            # Log number of spikes in the chunk.
+            nspikes += len(waveforms)
+        
+            # We sort waveforms by increasing order of fractional time.
+            [add_waveform(experiment, waveform) for waveform in sorted(waveforms)]
+            
+            first_chunk_detected = True
+        
         # Update the progress bar.
         progress_bar.update(rec/float(nrecs) + (float(s_end) / (nsamples*nrecs)),
             '%d spikes found.' % (nspikes))

--- a/spikedetekt2/core/script.py
+++ b/spikedetekt2/core/script.py
@@ -282,7 +282,10 @@ def main():
                        help='run only SpikeDetekt')
     parser.add_argument('--cluster-only', action='store_true', default=False,
                        help='run only KlustaKwik (after SpikeDetekt has run)')
-    parser.add_argument('--version', action='version', version='Klusta-Suite version {0:s}'.format(spikedetekt2.__version__))
+    parser.add_argument('--convert-only', action='store_true', default=False,
+                       help='only convert raw data to Kwik format, no spike detection')
+    parser.add_argument('--version', action='version', version='Klusta-Suite version {0:s}'.format(spikedetekt2.__version__))        
+
 
     args = parser.parse_args()
     
@@ -291,6 +294,9 @@ def main():
         runkk = False
     if args.cluster_only:
         runsd = False
+    if args.convert_only:
+        runsd = False
+        runkk = False
     
     run_all(args.prm_file, debug=args.debug, overwrite=args.overwrite,
             runsd=runsd, runkk=runkk)

--- a/spikedetekt2/processing/tests/test_threshold.py
+++ b/spikedetekt2/processing/tests/test_threshold.py
@@ -42,6 +42,12 @@ def test_get_threshold_1():
                               threshold_std_factor=(2., 4.),
                               use_single_threshold=False)
 
+    threshold3 = get_threshold(raw_data, filter=filter, 
+                              nexcerpts=nexcerpts,
+                              excerpt_size=excerpt_size,
+                              threshold_std_factor=np.array([[2.5, 2., 2., 2.3, 1.2], [4.5, 3.2, 1., 2.3, 3.4]]),
+                              use_single_threshold=False)
+
     # assert np.abs(np.array(threshold) - 4.5) < .5
     
     


### PR DESCRIPTION
The --convert-only option allows users to generate .high.kwd, .low.kwd, and .raw.kwd files using klusta without spike detection. A single chunk is detected, but the rest is ignored. This takes much less time than running the full spike detection algorithm every time.